### PR TITLE
:sparkles: Add: 서비스이용/개인정보처리방침 약관 API 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,8 @@ import { UsersModule } from "./modules/users/users.module";
 import { TravelNotesModule } from "src/modules/travel-notes/travel-notes.module";
 import { CountriesModule } from "src/modules/conuntries/countries.module";
 import { CitiesModule } from "src/modules/cities/cities.module";
-import { MagnetsModule } from './modules/magnets/magnets.module';
+import { MagnetsModule } from "./modules/magnets/magnets.module";
+import { TermsModule } from "./modules/terms/terms.module";
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { MagnetsModule } from './modules/magnets/magnets.module';
       { path: "/api/countries", module: CountriesModule },
       { path: "/api/cities", module: CitiesModule },
       { path: "/api/magnets", module: MagnetsModule },
+      { path: "/terms", module: TermsModule },
     ]),
   ],
   controllers: [AppController],

--- a/src/commons/constants/trazzle-service-terms.constant.ts
+++ b/src/commons/constants/trazzle-service-terms.constant.ts
@@ -1,0 +1,5 @@
+// 트래즐 서비스 이용약관
+export const TERMS_OF_SERVICE = "trazzle_services/trazzle_terms_of_service.pdf" as const;
+
+// 트래즐 개인정보 처리방침
+export const TERMS_OF_PERSONAL_INFORMATION = "trazzle_services/trazzle_terms_of_personal_information.pdf" as const;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,5 +4,14 @@ import { UsersModule } from "./users/users.module";
 import { TravelNotesModule } from "src/modules/travel-notes/travel-notes.module";
 import { CitiesModule } from "src/modules/cities/cities.module";
 import { MagnetsModule } from "src/modules/magnets/magnets.module";
+import { TermsModule } from "./terms/terms.module";
 
-export const MainModules = [CoreModule, UsersModule, TravelNotesModule, CountriesModule, CitiesModule, MagnetsModule];
+export const MainModules = [
+  CoreModule,
+  UsersModule,
+  TravelNotesModule,
+  CountriesModule,
+  CitiesModule,
+  MagnetsModule,
+  TermsModule,
+];

--- a/src/modules/terms/terms.controller.ts
+++ b/src/modules/terms/terms.controller.ts
@@ -1,0 +1,41 @@
+import { Controller, Get, Res } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { CustomConfigService } from "../core/config/custom-config.service";
+import { AwsS3Service } from "../core/aws-s3/aws-s3.service";
+import { TERMS_OF_PERSONAL_INFORMATION, TERMS_OF_SERVICE } from "src/commons/constants/trazzle-service-terms.constant";
+import { HttpService } from "@nestjs/axios";
+import { Response } from "express";
+
+@ApiTags("이용약관")
+@Controller()
+export class TermsController {
+  constructor(
+    private readonly customConfigService: CustomConfigService,
+    private readonly awsS3Service: AwsS3Service,
+    private readonly httpService: HttpService,
+  ) {}
+
+  @ApiOperation({ summary: "개인정보 처리방침 약관 조회" })
+  @Get("personal-info")
+  async getTermsOfPersonalInfo(@Res() res: Response) {
+    const data = await this.awsS3Service.getFileFromS3Bucket({ Key: TERMS_OF_PERSONAL_INFORMATION });
+    res.set({
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline;`,
+    });
+
+    res.send(data);
+  }
+
+  @ApiOperation({ summary: "서비스 이용 약관 조회" })
+  @Get("service")
+  async getTermsOfService(@Res() res: Response) {
+    const data = await this.awsS3Service.getFileFromS3Bucket({ Key: TERMS_OF_SERVICE });
+    res.set({
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline;`,
+    });
+
+    res.send(data);
+  }
+}

--- a/src/modules/terms/terms.module.ts
+++ b/src/modules/terms/terms.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { TermsController } from "./terms.controller";
+import { CustomConfigModule } from "../core/config/custom-config.module";
+import { AwsS3Module } from "../core/aws-s3/aws-s3.module";
+import { HttpModule } from "@nestjs/axios";
+
+@Module({
+  imports: [CustomConfigModule, AwsS3Module, HttpModule],
+  controllers: [TermsController],
+})
+export class TermsModule {}


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

- [개인정보 처리 방침 약관 조회](https://trazzle.atlassian.net/browse/TRAZ-43)
- [서비스 이용 약관 조회](https://trazzle.atlassian.net/browse/TRAZ-42)


## 🧐 기능 구현 내용(Optional)

---

API를 호출시 S3에 저장된 pdf파일을 리턴하도록 수정

두개의 API는 모두 public API 입니다.

개인정보 처리방침 : `[GET] /terms/personal`
<img width="771" alt="image" src="https://github.com/trazzle/trazzle-server/assets/129829722/e8c830eb-6d26-491e-8acd-45a18636d51b">


서비스 이용약관 조회: `[GET] /terms/service`
<img width="800" alt="image" src="https://github.com/trazzle/trazzle-server/assets/129829722/10fce995-54d0-4e07-a660-e8c2f91d6fdb">

시크릿키 추가는 따로 없습니다!


## 📭 이슈 번호

---

#3


