### PR TITLE
[은강] 여행국가 통계조회, 여행국가 개수 조회 API 

### DIFF
--- a/src/filters/all-exception.filter.ts
+++ b/src/filters/all-exception.filter.ts
@@ -15,9 +15,9 @@ export class AllExceptionFilter implements ExceptionFilter {
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
       path: request.url,
       timestamp: new Date().toISOString(),
-      error: "Internal Server Error",
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-      message: "Internal Server Error",
+      errorMessage: "Internal Server Error",
+      errorDetails: "Internal Server Error",
     });
   }
 }

--- a/src/modules/travel-notes/service/travel-notes.service.ts
+++ b/src/modules/travel-notes/service/travel-notes.service.ts
@@ -218,35 +218,4 @@ export class TravelNotesService {
       where: { id: id },
     });
   }
-
-  async getUserTravelStatistics(userId: number) {
-    // travel: travel-notes 개수
-    const travel = await this.prismaService.travelNote.count({
-      where: {
-        userId: userId,
-      },
-    });
-
-    // error
-    const worldOfAllCountries = await this.prismaService.country.count();
-
-    // countries: 여행한 국가개수
-    const data = await this.prismaService.travelNote.findMany({
-      select: {
-        id: true,
-        city: {
-          select: {
-            countryCode: true,
-          },
-        },
-      },
-      where: {
-        userId: userId,
-      },
-    });
-    console.log(data);
-
-    // world: 전세계 백분율
-    // const world = (countries / worldOfAllCountries) * 100;
-  }
 }

--- a/src/modules/travel-notes/service/travel-notes.service.ts
+++ b/src/modules/travel-notes/service/travel-notes.service.ts
@@ -218,4 +218,35 @@ export class TravelNotesService {
       where: { id: id },
     });
   }
+
+  async getUserTravelStatistics(userId: number) {
+    // travel: travel-notes 개수
+    const travel = await this.prismaService.travelNote.count({
+      where: {
+        userId: userId,
+      },
+    });
+
+    // error
+    const worldOfAllCountries = await this.prismaService.country.count();
+
+    // countries: 여행한 국가개수
+    const data = await this.prismaService.travelNote.findMany({
+      select: {
+        id: true,
+        city: {
+          select: {
+            countryCode: true,
+          },
+        },
+      },
+      where: {
+        userId: userId,
+      },
+    });
+    console.log(data);
+
+    // world: 전세계 백분율
+    // const world = (countries / worldOfAllCountries) * 100;
+  }
 }

--- a/src/modules/users/controllers/users.statistics.controller.ts
+++ b/src/modules/users/controllers/users.statistics.controller.ts
@@ -3,24 +3,26 @@ import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { BearerAuth } from "src/decorators/bearer-auth.decorator";
 import { SignInUser } from "src/decorators/sign-in-user.decorator";
 import { JwtAuthGuard } from "src/guards/jwt-auth.guard";
-import { TravelNotesService } from "src/modules/travel-notes/service/travel-notes.service";
+import { GetUserTravelStatisticResponseDto } from "src/modules/users/dtos/res/get-user-travel-statistics-response.dto";
 import { UserEntity } from "src/modules/users/entities/user.entity";
+import { UserStatisticsService } from "src/modules/users/services/statistics.service";
 
 @ApiTags("사용자 여행 통계")
 @Controller("statistics")
 export class UserStatisticsController {
-  constructor(private readonly travelNoteService: TravelNotesService) {}
+  constructor(private readonly statisticsService: UserStatisticsService) {}
 
-  @ApiOperation({ summary: "로그인한 회원이 작성한 여행기록 개수" })
+  @ApiOperation({ summary: "여행 국가 통계 조회" })
   @BearerAuth(JwtAuthGuard)
   @ApiOkResponse({
-    description: "여행기록 개수",
-    //   type:
+    description: "여행 국가 통계 정상 응답데이터",
+    type: GetUserTravelStatisticResponseDto,
   })
   @UseGuards(JwtAuthGuard)
   @Get()
   async getUserTravelStatistics(@SignInUser() user: UserEntity) {
     const { id } = user;
-    await this.travelNoteService.getUserTravelStatistics(id);
+    const result = await this.statisticsService.getUserTravelStatistics(id);
+    return result;
   }
 }

--- a/src/modules/users/controllers/users.statistics.controller.ts
+++ b/src/modules/users/controllers/users.statistics.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { BearerAuth } from "src/decorators/bearer-auth.decorator";
+import { SignInUser } from "src/decorators/sign-in-user.decorator";
+import { JwtAuthGuard } from "src/guards/jwt-auth.guard";
+import { TravelNotesService } from "src/modules/travel-notes/service/travel-notes.service";
+import { UserEntity } from "src/modules/users/entities/user.entity";
+
+@ApiTags("사용자 여행 통계")
+@Controller("statistics")
+export class UserStatisticsController {
+  constructor(private readonly travelNoteService: TravelNotesService) {}
+
+  @ApiOperation({ summary: "로그인한 회원이 작성한 여행기록 개수" })
+  @BearerAuth(JwtAuthGuard)
+  @ApiOkResponse({
+    description: "여행기록 개수",
+    //   type:
+  })
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  async getUserTravelStatistics(@SignInUser() user: UserEntity) {
+    const { id } = user;
+    await this.travelNoteService.getUserTravelStatistics(id);
+  }
+}

--- a/src/modules/users/dtos/res/get-user-travel-statistics-response.dto.ts
+++ b/src/modules/users/dtos/res/get-user-travel-statistics-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class GetUserTravelStatisticResponseDto {
+  @ApiProperty({
+    description: "여행기록 개수",
+    example: 4,
+  })
+  travel: number;
+
+  @ApiProperty({
+    description: "여행국가 개수",
+    example: 2,
+  })
+  countries: number;
+
+  @ApiProperty({
+    description: "세계여행 백분율",
+    example: "0.84%",
+  })
+  world: string;
+}

--- a/src/modules/users/dtos/res/get-user-travel-statistics-response.dto.ts
+++ b/src/modules/users/dtos/res/get-user-travel-statistics-response.dto.ts
@@ -14,8 +14,8 @@ export class GetUserTravelStatisticResponseDto {
   countries: number;
 
   @ApiProperty({
-    description: "세계여행 백분율",
-    example: "0.84%",
+    description: "세계여행 백분율(소수점아래 2자리만 표기)",
+    example: "0.84",
   })
   world: string;
 }

--- a/src/modules/users/services/statistics.service.ts
+++ b/src/modules/users/services/statistics.service.ts
@@ -50,7 +50,7 @@ export class UserStatisticsService {
       return {
         travel: countOfTravelNotes,
         countries: countOfCountries,
-        world: `${percentageOfWorld}%`,
+        world: percentageOfWorld,
       };
     });
   }

--- a/src/modules/users/services/statistics.service.ts
+++ b/src/modules/users/services/statistics.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "src/modules/core/database/prisma/prisma.service";
+import { GetUserTravelStatisticResponseDto } from "src/modules/users/dtos/res/get-user-travel-statistics-response.dto";
+
+@Injectable()
+export class UserStatisticsService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  getUserTravelStatistics(userId: number): Promise<GetUserTravelStatisticResponseDto> {
+    return this.prismaService.$transaction(async transaction => {
+      // travel: 사용자가 작성한 여행기록(travel-notes) 개수
+      const countOfTravelNotes = await transaction.travelNote.count({
+        where: {
+          userId: userId,
+        },
+      });
+
+      // userVisitedCountries: 사용자가 다녀온 국가
+      let userVisitedCountries = await transaction.travelNote.findMany({
+        where: {
+          userId: userId,
+        },
+        include: {
+          city: {
+            select: { countryCode: true },
+          },
+        },
+      });
+
+      userVisitedCountries = userVisitedCountries
+        .map(c => c.city.countryCode)
+        .reduce((acc, cur) => {
+          if (!acc.includes(cur)) {
+            acc.push(cur);
+          }
+
+          return acc;
+        }, []);
+
+      // countOfCountries: 사용자가 다녀온 국가 개수
+      const countOfCountries = userVisitedCountries.length;
+
+      // 전세계 개수
+      const totalOfCountries = await transaction.country.count();
+
+      // world: 여행국가 백분율
+      // 사용자가 다녀온 국가개수(countOfCountries) 를 전세계중 몇퍼센트인지 백분율로 나타냄
+      const percentageOfWorld = ((countOfCountries / totalOfCountries) * 100).toFixed(2);
+
+      return {
+        travel: countOfTravelNotes,
+        countries: countOfCountries,
+        world: `${percentageOfWorld}%`,
+      };
+    });
+  }
+}

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { CreateUserDto } from "../dtos/req/create-user.dto";
 import { UpdateUserDto } from "../dtos/req/update-user.dto";
-import { UpdateUserRequestBodyDto } from "../dtos/req/update-user-request-body.dto";
 import { AwsS3Service } from "src/modules/core/aws-s3/aws-s3.service";
 import { PrismaService } from "src/modules/core/database/prisma/prisma.service";
 

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,11 +4,13 @@ import { UsersController } from "./controllers/users.controller";
 import { PrismaModule } from "../core/database/prisma/prisma.module";
 import { CustomConfigModule } from "src/modules/core/config/custom-config.module";
 import { AwsS3Module } from "../core/aws-s3/aws-s3.module";
+import { TravelNotesModule } from "src/modules/travel-notes/travel-notes.module";
+import { UserStatisticsController } from "src/modules/users/controllers/users.statistics.controller";
 
 @Module({
-  imports: [PrismaModule, CustomConfigModule, AwsS3Module],
+  imports: [PrismaModule, CustomConfigModule, AwsS3Module, TravelNotesModule],
   providers: [UsersService],
-  controllers: [UsersController],
+  controllers: [UsersController, UserStatisticsController],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,12 +4,12 @@ import { UsersController } from "./controllers/users.controller";
 import { PrismaModule } from "../core/database/prisma/prisma.module";
 import { CustomConfigModule } from "src/modules/core/config/custom-config.module";
 import { AwsS3Module } from "../core/aws-s3/aws-s3.module";
-import { TravelNotesModule } from "src/modules/travel-notes/travel-notes.module";
 import { UserStatisticsController } from "src/modules/users/controllers/users.statistics.controller";
+import { UserStatisticsService } from "src/modules/users/services/statistics.service";
 
 @Module({
-  imports: [PrismaModule, CustomConfigModule, AwsS3Module, TravelNotesModule],
-  providers: [UsersService],
+  imports: [PrismaModule, CustomConfigModule, AwsS3Module],
+  providers: [UsersService, UserStatisticsService],
   controllers: [UsersController, UserStatisticsController],
   exports: [UsersService],
 })


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

[지라이슈 TRAZ-16](https://trazzle.atlassian.net/browse/TRAZ-16)
[지라이슈 TRAZ-17](https://trazzle.atlassian.net/browse/TRAZ-17)


## 🧐 기능 구현 내용(Optional)

---

- 메인화면 회원의 여행기록개수(travel) / 여행국가개수(countries) / 세계여행 백분율(world) 표기
- 지도집프로필(Figma my-map1) 도 해당

<br>

> API 호출방법: `[GET] /api/users/statistics`
- request-header.Authorization: required (accessToken 필요)

- [case 1]  여행기록이 있는경우, 정상응답 데이터
   - 일본여행 3개, 미국여행: 1개
```json
{
    "travel": 4,
    "countries": 2,
    "world": "0.84"
}
```

- [case 2] 여행기록이 없는경우, 정상응답데이터 (초기회원 데이터)
```json
{
    "travel": 0,
    "countries": 0,
    "world": "0.00"
}
```




## 📭 이슈 번호

---

https://github.com/EunKangChoi-Dyphi/potential-403-nestjs/issues/21

## 🖐️ 의견 구하기

---

소수점아래 몇자리까지 표기하는지 답변을 못받아서
소수점 아래 2번째 자리까지 표기했습니다.

ex) 0.84512 => 0.85 (세번째자리로부터 반올림 될 수 있습니다.)
ex) 0.84412 => 0.84 
